### PR TITLE
Switch tool parameters to serde_json::Value

### DIFF
--- a/mistralrs-core/src/search/mod.rs
+++ b/mistralrs-core/src/search/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 pub mod rag;
@@ -125,7 +124,7 @@ pub struct ExtractFunctionParameters {
 
 pub fn get_search_tools(web_search_options: &WebSearchOptions) -> Result<Vec<Tool>> {
     let search_tool = {
-        let parameters: HashMap<String, Value> = serde_json::from_value(json!({
+        let parameters = json!({
             "type": "object",
             "properties": {
                 "query": {
@@ -134,7 +133,7 @@ pub fn get_search_tools(web_search_options: &WebSearchOptions) -> Result<Vec<Too
                 },
             },
             "required": ["query"],
-        }))?;
+        });
 
         let location_details = match &web_search_options.user_location {
             Some(WebSearchUserLocation::Approximate { approximate }) => {
@@ -160,7 +159,7 @@ pub fn get_search_tools(web_search_options: &WebSearchOptions) -> Result<Vec<Too
     };
 
     let extract_tool = {
-        let parameters: HashMap<String, Value> = serde_json::from_value(json!({
+        let parameters = json!({
             "type": "object",
             "properties": {
                 "url": {
@@ -169,7 +168,7 @@ pub fn get_search_tools(web_search_options: &WebSearchOptions) -> Result<Vec<Too
                 },
             },
             "required": ["url"],
-        }))?;
+        });
 
         let description = web_search_options
             .extract_description

--- a/mistralrs-mcp/src/client/mod.rs
+++ b/mistralrs-mcp/src/client/mod.rs
@@ -291,15 +291,7 @@ fn tool_from_mcp(info: &McpToolInfo) -> LocalTool {
         function: Function {
             name: info.name.clone(),
             description: info.description.clone(),
-            parameters: if let serde_json::Value::Object(ref obj) = info.input_schema {
-                if let Some(serde_json::Value::Object(props)) = obj.get("properties") {
-                    Some(props.clone().into_iter().collect())
-                } else {
-                    Some(obj.clone().into_iter().collect())
-                }
-            } else {
-                None
-            },
+            parameters: Some(info.input_schema.clone()),
         },
     }
 }

--- a/mistralrs-mcp/src/tools.rs
+++ b/mistralrs-mcp/src/tools.rs
@@ -35,7 +35,7 @@ pub struct Function {
     pub description: Option<String>,
     pub name: String,
     #[serde(alias = "arguments")]
-    pub parameters: Option<HashMap<String, Value>>,
+    pub parameters: Option<Value>,
 }
 
 /// Tool definition

--- a/mistralrs/examples/custom_tool_call/main.rs
+++ b/mistralrs/examples/custom_tool_call/main.rs
@@ -48,10 +48,9 @@ async fn main() -> Result<()> {
         .await?;
 
     // Define the JSON schema for the tool the model can call.
-    let parameters = std::collections::HashMap::from([(
-        "query".to_string(),
-        serde_json::json!({"type": "string", "description": "Query"}),
-    )]);
+    let parameters = serde_json::json!({
+        "query": {"type": "string", "description": "Query"}
+    });
     let tool = Tool {
         tp: ToolType::Function,
         function: mistralrs::Function {

--- a/mistralrs/examples/tools/main.rs
+++ b/mistralrs/examples/tools/main.rs
@@ -1,11 +1,9 @@
-use std::collections::HashMap;
-
 use anyhow::Result;
 use mistralrs::{
     Function, IsqType, RequestBuilder, TextMessageRole, TextModelBuilder, Tool, ToolChoice,
     ToolType,
 };
-use serde_json::{json, Value};
+use serde_json::json;
 
 #[derive(serde::Deserialize, Debug, Clone)]
 struct GetWeatherInput {
@@ -24,7 +22,7 @@ async fn main() -> Result<()> {
         .build()
         .await?;
 
-    let parameters: HashMap<String, Value> = serde_json::from_value(json!({
+    let parameters = json!({
         "type": "object",
         "properties": {
             "place": {
@@ -33,7 +31,7 @@ async fn main() -> Result<()> {
             },
         },
         "required": ["place"],
-    }))?;
+    });
 
     let tools = vec![Tool {
         tp: ToolType::Function,


### PR DESCRIPTION
## Summary
- accept arbitrary JSON for MCP tool parameters
- adjust MCP client and search helper to use `serde_json::Value`
- update examples accordingly

## Testing
- `cargo fmt --all` *(fails: 'cargo-fmt' is not installed)*
- `cargo check --workspace` *(fails to fetch crates.io index)*
- `cargo test -p mistralrs-core -p mistralrs-mcp` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68665cae9898832ab9e82e8860f0fabb